### PR TITLE
fix require

### DIFF
--- a/lib/slugalizer/sugar.rb
+++ b/lib/slugalizer/sugar.rb
@@ -1,4 +1,4 @@
-require_relative '../slugalizer.rb'
+require 'slugalizer'
 
 class String
   def to_slug


### PR DESCRIPTION
`slugalizer` is already on the `$LOAD_PATH`, so there's no need to `require_relative` it.